### PR TITLE
Fix: remove seemore

### DIFF
--- a/src/utils/newsScraper/removeSeeMore.spec.ts
+++ b/src/utils/newsScraper/removeSeeMore.spec.ts
@@ -2,11 +2,15 @@ import { removeSeeMore } from './removeSeeMore';
 
 describe('removeSeeMore', () => {
     it('removes see more from the end of a string', () => {
-        const text = 'Usun... więcej';
+        const text = 'Usun… więcej';
+        expect(removeSeeMore(text)).toEqual('Usun...');
+    });
+    it('removes see more from the end of a string and additional characters', () => {
+        const text = 'Usun,- … więcej';
         expect(removeSeeMore(text)).toEqual('Usun...');
     });
     it('doesnt remove see more from the end of a string', () => {
-        const text = 'Nie usuwaj...';
-        expect(removeSeeMore(text)).toEqual('Nie usuwaj...');
+        const text = 'Nie usuwaj…';
+        expect(removeSeeMore(text)).toEqual('Nie usuwaj…');
     });
 });

--- a/src/utils/newsScraper/removeSeeMore.ts
+++ b/src/utils/newsScraper/removeSeeMore.ts
@@ -1,5 +1,5 @@
 export const removeSeeMore = (text: string) => {
-    const regex = /... więcej$/;
+    const regex = /([,|\s|-])*… więcej$/;
     const newText = text.replace(regex, '...');
     return newText;
 };


### PR DESCRIPTION
## Description
Correct the function to avoid splitting words in half and ensure it removes spaces and other characters before '...'.


## Clickup Ticket

https://app.clickup.com/t/862kjtruv